### PR TITLE
Expose SQL functions as operations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,6 @@
 
 ThisBuild / organization := "io.github.nuzigor"
 ThisBuild / organizationName := "nuzigor"
-//ThisBuild / name := "h3-spark"
 ThisBuild / description := "Brings H3 - Hexagonal hierarchical geospatial indexing system support to Apache Spark SQL."
 ThisBuild / homepage := Some(url("https://github.com/nuzigor/h3-spark"))
 ThisBuild / licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))

--- a/src/main/scala/com/nuzigor/spark/sql/h3/functions.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/functions.scala
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2021 Igor Nuzhnov
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.nuzigor.spark.sql.h3
+
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
+
+// scalastyle:off
+object functions {
+// scalastyle:on
+  private def withExpr(expr: Expression): Column = new Column(expr)
+
+  // scalastyle:off method.name
+  /**
+   * Computes h3 address from latitude and longitude at target resolution.
+   * @param latitude latitude in degrees
+   * @param longitude longitude in degrees
+   * @param resolution target resolution
+   * @return h3 address
+   */
+  def h3_from_geo(latitude: Column, longitude: Column, resolution: Int): Column = withExpr {
+    FromGeo(latitude.expr, longitude.expr, Literal(resolution))
+  }
+
+  /**
+   * Computes h3 address from a WKT string at target resolution.
+   * @param wkt point object in WKT format
+   * @param resolution target resolution
+   * @return h3 address
+   */
+  def h3_from_wkt(wkt: Column, resolution: Int): Column = withExpr {
+    FromWkt(wkt.expr, Literal(resolution))
+  }
+
+  /**
+   * Computes h3 addresses from a WKT geometry.
+   * @param wkt geometry object in WKT format, supports POINT, MULTIPOINT, LINESTRING, MULTILINESTRING, POLYGON, MULTIPOLYGON
+   * @param resolution target resolution
+   * @return array of h3 addresses
+   */
+  def h3_array_from_wkt(wkt: Column, resolution: Int): Column = withExpr {
+    ArrayFromWkt(wkt.expr, Literal(resolution))
+  }
+
+  /**
+   * Computes h3 indices within k distance of the origin index.
+   * @param origin h3 index
+   * @param k distance
+   * @return array of h3 indices
+   */
+  def h3_k_ring(origin: Column, k: Int): Column = withExpr {
+    KRing(origin.expr, Literal(k))
+  }
+
+  /**
+   * Computes hollow hexagonal ring centered at origin with sides of length k.
+   * @param origin h3 index
+   * @param k distance
+   * @return array of h3 indices
+   */
+  def h3_hex_ring(origin: Column, k: Int): Column = withExpr {
+    HexRing(origin.expr, Literal(k))
+  }
+
+  /**
+   * Computes the line of indices between start and end.
+   * @param start start h3 index
+   * @param end end h3 index
+   * @return array of h3 indices
+   */
+  def h3_line(start: Column, end: Column): Column = withExpr {
+    Line(start.expr, end.expr)
+  }
+
+  /**
+   * Computes the distance in grid cells between start and end.
+   * @param start start h3 index
+   * @param end end h3 index
+   * @return distance between cells
+   */
+  def h3_distance(start: Column, end: Column): Column = withExpr {
+    Distance(start.expr, end.expr)
+  }
+
+  /**
+   * Returns the resolution of h3 index.
+   * @param h3 h3 index
+   * @return resolution
+   */
+  def h3_get_resolution(h3: Column): Column = withExpr {
+    GetResolution(h3.expr)
+  }
+
+  /**
+   * Returns true if h3 index is valid
+   * @param h3 h3 index
+   * @return true if valid, false otherwise
+   */
+  def h3_is_valid(h3: Column): Column = withExpr {
+    IsValid(h3.expr)
+  }
+
+  /**
+   * Returns the parent (coarser) index containing h3.
+   * @param h3 child h3 index
+   * @param parentResolution parent index resolution
+   * @return parent h3 index
+   */
+  def h3_to_parent(h3: Column, parentResolution: Int): Column = withExpr {
+    ToParent(h3.expr, Literal(parentResolution))
+  }
+
+  /**
+   * Returns h3 indices contained within of the original index and child resolution.
+   * @param h3 parent h3 index
+   * @param childResolution child resolution
+   * @return array of child h3 indices
+   */
+  def h3_to_children(h3: Column, childResolution: Int): Column = withExpr {
+    ToChildren(h3.expr, Literal(childResolution))
+  }
+
+  /**
+   * Computes the center child of h3 index at child resolution.
+   * @param h3 parent h3 index
+   * @param childResolution child resolution
+   * @return child h3 index
+   */
+  def h3_to_center_child(h3: Column, childResolution: Int): Column = withExpr {
+    ToCenterChild(h3.expr, Literal(childResolution))
+  }
+
+  /**
+   * Returns the compacted array on indices.
+   * @param h3 array of h3 indices
+   * @return compacted array oh h3 indices
+   */
+  def h3_compact(h3: Column): Column = withExpr {
+    Compact(h3.expr)
+  }
+
+  /**
+   * Un-compacts the set of indices using the target resolution.
+   * @param h3 array of h3 indices
+   * @param resolution target resolution
+   * @return un-compacted array of h3 indices
+   */
+  def h3_uncompact(h3: Column, resolution: Int): Column = withExpr {
+    Uncompact(h3.expr, Literal(resolution))
+  }
+  // scalastyle:on method.name
+}

--- a/src/test/scala/com/nuzigor/spark/sql/h3/DistanceSpec.scala
+++ b/src/test/scala/com/nuzigor/spark/sql/h3/DistanceSpec.scala
@@ -5,6 +5,9 @@
 
 package com.nuzigor.spark.sql.h3
 
+import com.nuzigor.spark.sql.h3.functions._
+import org.apache.spark.sql.functions.column
+
 class DistanceSpec extends H3Spec {
   it should "return distance in hexes between start and end indices" in {
     val start = 622485130170957823L
@@ -36,6 +39,14 @@ class DistanceSpec extends H3Spec {
     val start = 622485130170957823L
     val spatialDf = sparkSession.sql(s"SELECT h3_distance(${start}l, null)")
     assert(spatialDf.first().isNullAt(0))
+  }
+
+  it should "support compiled function" in {
+    import sparkSession.implicits._
+    val df = Seq((622485130170957823L, 622485130170302463L)).toDF("start", "end")
+    val result = df.select(h3_distance(column("start"), column("end")).alias("h3"))
+    val distance = result.first().getAs[Int](0)
+    assert(distance === 4)
   }
 
   protected override def functionName: String = "h3_distance"

--- a/src/test/scala/com/nuzigor/spark/sql/h3/FromGeoSpec.scala
+++ b/src/test/scala/com/nuzigor/spark/sql/h3/FromGeoSpec.scala
@@ -5,6 +5,9 @@
 
 package com.nuzigor.spark.sql.h3
 
+import com.nuzigor.spark.sql.h3.functions._
+import org.apache.spark.sql.functions.column
+
 class FromGeoSpec extends H3Spec {
   it should "convert point to h3" in {
     val spatialDf = sparkSession.sql("SELECT h3_from_geo(35.8466667d, -0.2983396d, 10)")
@@ -25,6 +28,15 @@ class FromGeoSpec extends H3Spec {
   it should "return null for null resolution" in {
     val spatialDf = sparkSession.sql("SELECT h3_from_geo(35.8466667d, -0.2983396d, null)")
     assert(spatialDf.first().isNullAt(0))
+  }
+
+  it should "support compiled function" in {
+    import sparkSession.implicits._
+    val df = Seq((35.8466667d, -0.2983396d)).toDF("lat", "lng")
+    val resolution = 10
+    val result = df.select(h3_from_geo(column("lat"), column("lng"), resolution).alias("h3"))
+    val h3 = result.first().getAs[Long](0)
+    assert(h3 === 0x8A382ED85C37FFFL)
   }
 
   protected override def functionName: String = "h3_from_geo"

--- a/src/test/scala/com/nuzigor/spark/sql/h3/FromWktSpec.scala
+++ b/src/test/scala/com/nuzigor/spark/sql/h3/FromWktSpec.scala
@@ -5,6 +5,9 @@
 
 package com.nuzigor.spark.sql.h3
 
+import com.nuzigor.spark.sql.h3.functions._
+import org.apache.spark.sql.functions.column
+
 class FromWktSpec extends H3Spec {
   it should "convert WKT point to h3" in {
     val spatialDf = sparkSession.sql("SELECT h3_from_wkt('POINT (-0.2983396 35.8466667)', 10)")
@@ -30,6 +33,15 @@ class FromWktSpec extends H3Spec {
   it should "return null for null resolution" in {
     val spatialDf = sparkSession.sql("SELECT h3_from_wkt('POINT (-0.2983396 35.8466667)', null)")
     assert(spatialDf.first().isNullAt(0))
+  }
+
+  it should "support compiled function" in {
+    import sparkSession.implicits._
+    val df = Seq(("POINT (-0.2983396 35.8466667)", 1)).toDF("wkt", "id")
+    val resolution = 10
+    val result = df.select(h3_from_wkt(column("wkt"), resolution).alias("h3"))
+    val h3 = result.first().getAs[Long](0)
+    assert(h3 === 0x8A382ED85C37FFFL)
   }
 
   protected override def functionName: String = "h3_from_wkt"

--- a/src/test/scala/com/nuzigor/spark/sql/h3/GetResolutionSpec.scala
+++ b/src/test/scala/com/nuzigor/spark/sql/h3/GetResolutionSpec.scala
@@ -5,6 +5,9 @@
 
 package com.nuzigor.spark.sql.h3
 
+import com.nuzigor.spark.sql.h3.functions._
+import org.apache.spark.sql.functions.column
+
 class GetResolutionSpec extends H3Spec {
   it should "return h3 index resolution" in {
     val h3 = 622485130170302463L
@@ -21,6 +24,15 @@ class GetResolutionSpec extends H3Spec {
   it should "not return null for invalid h3" in {
     val spatialDf = sparkSession.sql(s"SELECT h3_get_resolution(-1)")
     assert(!spatialDf.first().isNullAt(0))
+  }
+
+  it should "support compiled function" in {
+    import sparkSession.implicits._
+    val h3 = 622485130170302463L
+    val df = Seq((h3, 1)).toDF("h3", "id")
+    val result = df.select(h3_get_resolution(column("h3")).alias("res"))
+    val resolution = result.first().getAs[Int](0)
+    assert(resolution === 10)
   }
 
   protected override def functionName: String = "h3_get_resolution"

--- a/src/test/scala/com/nuzigor/spark/sql/h3/HexRingSpec.scala
+++ b/src/test/scala/com/nuzigor/spark/sql/h3/HexRingSpec.scala
@@ -5,6 +5,9 @@
 
 package com.nuzigor.spark.sql.h3
 
+import com.nuzigor.spark.sql.h3.functions._
+import org.apache.spark.sql.functions.column
+
 class HexRingSpec extends H3Spec {
   it should "create hollow ring around h3 index" in {
     val h3 = 622485130170302463L
@@ -28,6 +31,16 @@ class HexRingSpec extends H3Spec {
   it should "return null for invalid h3" in {
     val spatialDf = sparkSession.sql(s"SELECT h3_hex_ring(-1, 2)")
     assert(spatialDf.first().isNullAt(0))
+  }
+
+  it should "support compiled function" in {
+    import sparkSession.implicits._
+    val h3 = 622485130170302463L
+    val df = Seq((h3, 1)).toDF("h3", "id")
+    val result = df.select(h3_hex_ring(column("h3"), 2).alias("ring"))
+    val ring = result.first().getAs[Seq[Long]](0)
+    assert(ring.size === 12)
+    assert(!ring.contains(h3))
   }
 
   protected override def functionName: String = "h3_hex_ring"

--- a/src/test/scala/com/nuzigor/spark/sql/h3/IsValidSpec.scala
+++ b/src/test/scala/com/nuzigor/spark/sql/h3/IsValidSpec.scala
@@ -5,6 +5,9 @@
 
 package com.nuzigor.spark.sql.h3
 
+import com.nuzigor.spark.sql.h3.functions._
+import org.apache.spark.sql.functions.column
+
 class IsValidSpec extends H3Spec {
   it should "return true for valid h3 index" in {
     val h3 = 622485130170302463L
@@ -22,6 +25,15 @@ class IsValidSpec extends H3Spec {
   it should "return null for null h3 index" in {
     val spatialDf = sparkSession.sql("SELECT h3_is_valid(null)")
     assert(spatialDf.first().isNullAt(0))
+  }
+
+  it should "support compiled function" in {
+    import sparkSession.implicits._
+    val h3 = 622485130170302463L
+    val df = Seq((h3, 1)).toDF("h3", "id")
+    val result = df.select(h3_is_valid(column("h3")).alias("valid"))
+    val isValid = result.first().getAs[Boolean](0)
+    assert(isValid)
   }
 
   protected override def functionName: String = "h3_is_valid"

--- a/src/test/scala/com/nuzigor/spark/sql/h3/KRingSpec.scala
+++ b/src/test/scala/com/nuzigor/spark/sql/h3/KRingSpec.scala
@@ -5,6 +5,9 @@
 
 package com.nuzigor.spark.sql.h3
 
+import com.nuzigor.spark.sql.h3.functions._
+import org.apache.spark.sql.functions.column
+
 class KRingSpec extends H3Spec {
   it should "create ring around h3 index" in {
     val h3 = 622485130170302463L
@@ -28,6 +31,16 @@ class KRingSpec extends H3Spec {
   it should "not return null for invalid h3" in {
     val spatialDf = sparkSession.sql(s"SELECT h3_k_ring(0l, 2)")
     assert(!spatialDf.first().isNullAt(0))
+  }
+
+  it should "support compiled function" in {
+    import sparkSession.implicits._
+    val h3 = 622485130170302463L
+    val df = Seq((h3, 1)).toDF("h3", "id")
+    val result = df.select(h3_k_ring(column("h3"), 1).alias("ring"))
+    val ring = result.first().getAs[Seq[Long]](0)
+    assert(ring.size === 7)
+    assert(ring.contains(h3))
   }
 
   protected override def functionName: String = "h3_k_ring"

--- a/src/test/scala/com/nuzigor/spark/sql/h3/LineSpec.scala
+++ b/src/test/scala/com/nuzigor/spark/sql/h3/LineSpec.scala
@@ -5,6 +5,9 @@
 
 package com.nuzigor.spark.sql.h3
 
+import com.nuzigor.spark.sql.h3.functions._
+import org.apache.spark.sql.functions.column
+
 class LineSpec extends H3Spec {
   it should "return indices line between start and end indices" in {
     val start = 622485130170957823L
@@ -38,6 +41,18 @@ class LineSpec extends H3Spec {
     val start = 622485130170957823L
     val spatialDf = sparkSession.sql(s"SELECT h3_line(${start}l, -1l)")
     assert(spatialDf.first().isNullAt(0))
+  }
+
+  it should "support compiled function" in {
+    import sparkSession.implicits._
+    val start = 622485130170957823L
+    val end = 622485130170302463L
+    val df = Seq((start, end)).toDF("start", "end")
+    val result = df.select(h3_line(column("start"), column("end")).alias("line"))
+    val line = result.first().getAs[Seq[Long]](0)
+    assert(line.size === 5)
+    assert(line.contains(start))
+    assert(line.contains(end))
   }
 
   protected override def functionName: String = "h3_line"

--- a/src/test/scala/com/nuzigor/spark/sql/h3/ToCenterChildSpec.scala
+++ b/src/test/scala/com/nuzigor/spark/sql/h3/ToCenterChildSpec.scala
@@ -5,6 +5,9 @@
 
 package com.nuzigor.spark.sql.h3
 
+import com.nuzigor.spark.sql.h3.functions._
+import org.apache.spark.sql.functions.column
+
 class ToCenterChildSpec extends H3Spec {
   it should "return center child of h3 index" in {
     val h3 = 622485130170302463L
@@ -27,6 +30,16 @@ class ToCenterChildSpec extends H3Spec {
   it should "not return null for invalid h3" in {
     val spatialDf = sparkSession.sql(s"SELECT h3_to_center_child(0l, 2)")
     assert(!spatialDf.first().isNullAt(0))
+  }
+
+  it should "support compiled function" in {
+    import sparkSession.implicits._
+    val h3 = 622485130170302463L
+    val df = Seq((h3, 1)).toDF("h3", "id")
+    val resolution = 11
+    val result = df.select(h3_to_center_child(column("h3"), resolution).alias("child"))
+    val child = result.first().getAs[Long](0)
+    assert(child === 626988729797644287L)
   }
 
   protected override def functionName: String = "h3_to_center_child"

--- a/src/test/scala/com/nuzigor/spark/sql/h3/ToChildrenSpec.scala
+++ b/src/test/scala/com/nuzigor/spark/sql/h3/ToChildrenSpec.scala
@@ -5,6 +5,9 @@
 
 package com.nuzigor.spark.sql.h3
 
+import com.nuzigor.spark.sql.h3.functions._
+import org.apache.spark.sql.functions.column
+
 class ToChildrenSpec extends H3Spec {
   it should "return children of h3 index" in {
     val h3 = 622485130170302463L
@@ -29,6 +32,18 @@ class ToChildrenSpec extends H3Spec {
   it should "not return null for invalid h3" in {
     val spatialDf = sparkSession.sql(s"SELECT h3_to_children(0l, 2)")
     assert(!spatialDf.first().isNullAt(0))
+  }
+
+  it should "support compiled function" in {
+    import sparkSession.implicits._
+    val h3 = 622485130170302463L
+    val df = Seq((h3, 1)).toDF("h3", "id")
+    val resolution = 11
+    val result = df.select(h3_to_children(column("h3"), resolution).alias("children"))
+    val children = result.first().getAs[Seq[Long]](0)
+    assert(children.size === 7)
+    val childH3 = 626988729797656575L
+    assert(children.contains(childH3))
   }
 
   protected override def functionName: String = "h3_to_children"

--- a/src/test/scala/com/nuzigor/spark/sql/h3/ToParentSpec.scala
+++ b/src/test/scala/com/nuzigor/spark/sql/h3/ToParentSpec.scala
@@ -5,6 +5,9 @@
 
 package com.nuzigor.spark.sql.h3
 
+import com.nuzigor.spark.sql.h3.functions._
+import org.apache.spark.sql.functions.column
+
 class ToParentSpec extends H3Spec {
   it should "return h3 parent index" in {
     val h3 = 622485130170302463L
@@ -22,6 +25,16 @@ class ToParentSpec extends H3Spec {
     val h3 = 622485130170302463L
     val spatialDf = sparkSession.sql(s"SELECT h3_to_parent(${h3}l, null)")
     assert(spatialDf.first().isNullAt(0))
+  }
+
+  it should "support compiled function" in {
+    import sparkSession.implicits._
+    val h3 = 622485130170302463L
+    val df = Seq((h3, 1)).toDF("h3", "id")
+    val resolution = 8
+    val result = df.select(h3_to_parent(column("h3"), resolution).alias("parent"))
+    val parent = result.first().getAs[Long](0)
+    assert(parent === 613477930917429247L)
   }
 
   protected override def functionName: String = "h3_to_parent"

--- a/src/test/scala/com/nuzigor/spark/sql/h3/UncompactSpec.scala
+++ b/src/test/scala/com/nuzigor/spark/sql/h3/UncompactSpec.scala
@@ -5,6 +5,9 @@
 
 package com.nuzigor.spark.sql.h3
 
+import com.nuzigor.spark.sql.h3.functions._
+import org.apache.spark.sql.functions.column
+
 class UncompactSpec extends H3Spec {
   it should "uncompact h3 indices" in {
     val h3 = 622485130170302463L
@@ -33,6 +36,16 @@ class UncompactSpec extends H3Spec {
   it should "not return null for invalid h3" in {
     val spatialDf = sparkSession.sql(s"SELECT h3_uncompact(array(0, 2), 3)")
     assert(!spatialDf.first().isNullAt(0))
+  }
+
+  it should "support compiled function" in {
+    import sparkSession.implicits._
+    val h3 = 622485130170302463L
+    val df = Seq((h3, 1)).toDF("h3", "id")
+    val resolution = 11
+    val result = df.select(h3_uncompact(h3_k_ring(column("h3"), 1), resolution).alias("result"))
+    val uncompacted = result.first().getAs[Seq[Long]](0)
+    assert(uncompacted.size > 7)
   }
 
   protected override def functionName: String = "h3_uncompact"


### PR DESCRIPTION
Expose all Spark SQL functions as compiled operations
closes #8 