### PR TITLE
Bump all versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ ThisBuild / description := "Brings H3 - Hexagonal hierarchical geospatial indexi
 ThisBuild / homepage := Some(url("https://github.com/nuzigor/h3-spark"))
 ThisBuild / licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 ThisBuild / versionScheme := Some("semver-spec")
-ThisBuild / version      := "0.7.0"
+ThisBuild / version      := "0.8.0"
 
 ThisBuild / developers := List(
   Developer(
@@ -46,10 +46,10 @@ lazy val root = (project in file("."))
     name := "h3-spark"
   )
 
-val sparkVersion = "3.1.2"
-val h3Version = "3.7.1"
+val sparkVersion = "3.2.1"
+val h3Version = "3.7.2"
 val jtsVersion = "1.18.2"
-val scalatestVersion = "3.2.10"
+val scalatestVersion = "3.2.11"
 val scalacheckVersion = "1.15.4"
 
 libraryDependencies ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.6.2

--- a/project/site.sbt
+++ b/project/site.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")

--- a/src/main/scala/com/nuzigor/spark/sql/h3/AreNeighbors.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/AreNeighbors.scala
@@ -13,8 +13,8 @@ import org.apache.spark.sql.types.{BooleanType, DataType, LongType}
 /**
  * Returns whether or not the provided h3 indexes are neighbors.
  *
- * @param originExpr h3 origin.
- * @param destinationExpr h3 destination.
+ * @param left h3 origin.
+ * @param right h3 destination.
  */
 @ExpressionDescription(
   usage = "_FUNC_(origin, destination) - Returns true if the provided h3 indices are neighbors.",
@@ -31,11 +31,9 @@ import org.apache.spark.sql.types.{BooleanType, DataType, LongType}
           false
      """,
   since = "0.7.0")
-case class AreNeighbors(originExpr: Expression, destinationExpr: Expression)
+case class AreNeighbors(left: Expression, right: Expression)
   extends BinaryExpression with CodegenFallback with ImplicitCastInputTypes with NullIntolerant {
 
-  override def left: Expression = originExpr
-  override def right: Expression = destinationExpr
   override def inputTypes: Seq[DataType] = Seq(LongType, LongType)
   override def dataType: DataType = BooleanType
 
@@ -44,4 +42,6 @@ case class AreNeighbors(originExpr: Expression, destinationExpr: Expression)
     val destination = endAny.asInstanceOf[Long]
     H3.getInstance().h3IndexesAreNeighbors(origin, destination)
   }
+
+  override protected def withNewChildrenInternal(newLeft: Expression, newRight: Expression): AreNeighbors = copy(left = newLeft, right = newRight)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/ArrayFromWkt.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/ArrayFromWkt.scala
@@ -23,8 +23,8 @@ import scala.collection.JavaConverters._
 /**
  * Return h3 addresses from a WKT geometry.
  *
- * @param wktExpr geometry in WKT format, supports POINT, MULTIPOINT, LINESTRING, MULTILINESTRING, POLYGON, MULTIPOLYGON.
- * @param resolutionExpr h3 resolution
+ * @param left geometry in WKT format, supports POINT, MULTIPOINT, LINESTRING, MULTILINESTRING, POLYGON, MULTIPOLYGON.
+ * @param right h3 resolution
  */
 @ExpressionDescription(
   usage = "_FUNC_(wkt, resolution) - Returns h3 addresses from a WKT geometry.",
@@ -58,15 +58,13 @@ import scala.collection.JavaConverters._
      """,
   group = "array_funcs",
   since = "0.1.0")
-case class ArrayFromWkt(wktExpr: Expression, resolutionExpr: Expression,
+case class ArrayFromWkt(left: Expression, right: Expression,
                         failOnError: Boolean = SQLConf.get.ansiEnabled)
   extends BinaryExpression with CodegenFallback with ImplicitCastInputTypes with NullIntolerant {
 
-  def this(wktExpr: Expression, resolutionExpr: Expression) =
-    this(wktExpr, resolutionExpr, SQLConf.get.ansiEnabled)
+  def this(left: Expression, right: Expression) =
+    this(left, right, SQLConf.get.ansiEnabled)
 
-  override def left: Expression = wktExpr
-  override def right: Expression = resolutionExpr
   override def inputTypes: Seq[DataType] = Seq(StringType, IntegerType)
   override def dataType: DataType = ArrayType(LongType, containsNull = false)
   override def nullable: Boolean = true
@@ -145,4 +143,6 @@ case class ArrayFromWkt(wktExpr: Expression, resolutionExpr: Expression,
           .map(Long2long)
       })
   }
+
+  override protected def withNewChildrenInternal(newLeft: Expression, newRight: Expression): ArrayFromWkt = copy(left = newLeft, right = newRight)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/CellArea.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/CellArea.scala
@@ -8,19 +8,17 @@ package com.nuzigor.spark.sql.h3
 import com.nuzigor.h3.H3
 import com.uber.h3core.AreaUnit
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
-import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes, NullIntolerant, UnaryExpression}
+import org.apache.spark.sql.catalyst.expressions.{ImplicitCastInputTypes, NullIntolerant, UnaryExpression}
 import org.apache.spark.sql.types.{DataType, DoubleType, LongType}
 
 /**
  * Exact area of specific cell in area units.
  */
-trait CellArea
+abstract class CellArea
   extends UnaryExpression with CodegenFallback with ImplicitCastInputTypes with NullIntolerant {
 
-  def h3Expr: Expression
   def unit: AreaUnit
 
-  override def child: Expression = h3Expr
   override def inputTypes: Seq[DataType] = Seq(LongType)
   override def dataType: DataType = DoubleType
 

--- a/src/main/scala/com/nuzigor/spark/sql/h3/CellAreaKm2.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/CellAreaKm2.scala
@@ -11,7 +11,7 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescript
 /**
  * Exact area of specific cell in square kilometers.
  *
- * @param h3Expr h3 index.
+ * @param child h3 index.
  */
 @ExpressionDescription(
   usage = "_FUNC_(h3) - Returns the exact area of specific cell in square kilometers.",
@@ -26,6 +26,8 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescript
           0.0148
      """,
   since = "0.7.0")
-case class CellAreaKm2(h3Expr: Expression) extends CellArea {
+case class CellAreaKm2(child: Expression) extends CellArea {
   override def unit: AreaUnit = AreaUnit.km2
+
+  override protected def withNewChildInternal(newChild: Expression): CellAreaKm2 = copy(child = newChild)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/CellAreaM2.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/CellAreaM2.scala
@@ -11,7 +11,7 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescript
 /**
  * Exact area of specific cell in square meters.
  *
- * @param h3Expr h3 index.
+ * @param child h3 index.
  */
 @ExpressionDescription(
   usage = "_FUNC_(h3) - Returns the exact area of specific cell in square meters.",
@@ -26,6 +26,8 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescript
           14812.0
      """,
   since = "0.7.0")
-case class CellAreaM2(h3Expr: Expression) extends CellArea {
+case class CellAreaM2(child: Expression) extends CellArea {
   override def unit: AreaUnit = AreaUnit.m2
+
+  override protected def withNewChildInternal(newChild: Expression): CellAreaM2 = copy(child = newChild)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/CellAreaRads2.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/CellAreaRads2.scala
@@ -11,7 +11,7 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescript
 /**
  * Exact area of specific cell in square radians.
  *
- * @param h3Expr h3 index.
+ * @param child h3 index.
  */
 @ExpressionDescription(
   usage = "_FUNC_(h3) - Returns the exact area of specific cell in square radians.",
@@ -26,6 +26,8 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescript
           3.65E-10
      """,
   since = "0.7.0")
-case class CellAreaRads2(h3Expr: Expression) extends CellArea {
+case class CellAreaRads2(child: Expression) extends CellArea {
   override def unit: AreaUnit = AreaUnit.rads2
+
+  override protected def withNewChildInternal(newChild: Expression): CellAreaRads2 = copy(child = newChild)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/Compact.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/Compact.scala
@@ -17,7 +17,7 @@ import scala.collection.JavaConverters._
 /**
  * Compacts the set of indices as best as possible.
  *
- * @param h3Expr h3 indices.
+ * @param child h3 indices.
  */
 @ExpressionDescription(
   usage = "_FUNC_(expr) - Returns the compacted `expr` array on indices.",
@@ -35,15 +35,14 @@ import scala.collection.JavaConverters._
      """,
   group = "array_funcs",
   since = "0.1.0")
-case class Compact(h3Expr: Expression,
+case class Compact(child: Expression,
                    failOnError: Boolean = SQLConf.get.ansiEnabled)
   extends UnaryExpression with CodegenFallback with ImplicitCastInputTypes with NullIntolerant with ArrayListConversion {
 
-  def this(h3Expr: Expression) = this(h3Expr, SQLConf.get.ansiEnabled)
+  def this(child: Expression) = this(child, SQLConf.get.ansiEnabled)
 
   @transient private lazy val nullEntries: Boolean = child.dataType.asInstanceOf[ArrayType].containsNull
 
-  override def child: Expression = h3Expr
   override def inputTypes: Seq[DataType] = Seq(ArrayType(LongType))
   override def dataType: DataType = ArrayType(LongType, containsNull = false)
   override def nullable: Boolean = !failOnError || child.nullable || nullEntries
@@ -61,4 +60,6 @@ case class Compact(h3Expr: Expression,
       case None => null
     }
   }
+
+  override protected def withNewChildInternal(newChild: Expression): Compact = copy(child = newChild)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/Distance.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/Distance.scala
@@ -15,8 +15,8 @@ import org.apache.spark.sql.types.{DataType, IntegerType, LongType}
 /**
  * Returns the distance in grid cells between start and end.
  *
- * @param startExpr h3 start.
- * @param endExpr h3 end.
+ * @param left h3 start.
+ * @param right h3 end.
  */
 @ExpressionDescription(
   usage = "_FUNC_(start, end) - Returns the distance in grid cells between start and end.",
@@ -33,13 +33,11 @@ import org.apache.spark.sql.types.{DataType, IntegerType, LongType}
           4
      """,
   since = "0.1.0")
-case class Distance(startExpr: Expression, endExpr: Expression, failOnError: Boolean = SQLConf.get.ansiEnabled)
+case class Distance(left: Expression, right: Expression, failOnError: Boolean = SQLConf.get.ansiEnabled)
   extends BinaryExpression with CodegenFallback with ImplicitCastInputTypes with NullIntolerant {
 
-  def this(startExpr: Expression, endExpr: Expression) = this(startExpr, endExpr, SQLConf.get.ansiEnabled)
+  def this(left: Expression, right: Expression) = this(left, right, SQLConf.get.ansiEnabled)
 
-  override def left: Expression = startExpr
-  override def right: Expression = endExpr
   override def inputTypes: Seq[DataType] = Seq(LongType, LongType)
   override def dataType: DataType = IntegerType
   override def nullable: Boolean = !failOnError || super.nullable
@@ -54,4 +52,6 @@ case class Distance(startExpr: Expression, endExpr: Expression, failOnError: Boo
       case _: DistanceUndefinedException if !failOnError => null
     }
   }
+
+  override protected def withNewChildrenInternal(newLeft: Expression, newRight: Expression): Distance = copy(left = newLeft, right = newRight)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/FromGeo.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/FromGeo.scala
@@ -14,9 +14,9 @@ import org.apache.spark.sql.types.{DataType, DoubleType, IntegerType, LongType}
 /**
  * Returns h3 address from latitude and longitude for at specific resolution.
  *
- * @param latitudeExpr the latitude.
- * @param longitudeExpr the longitude.
- * @param resolutionExpr h3 resolution
+ * @param first the latitude.
+ * @param second the longitude.
+ * @param third h3 resolution
  */
 @ExpressionDescription(
   usage = "_FUNC_(latitude, longitude, resolution) - Returns h3 address from latitude and longitude at target resolution.",
@@ -35,16 +35,15 @@ import org.apache.spark.sql.types.{DataType, DoubleType, IntegerType, LongType}
           617057114733412351
      """,
   since = "0.1.0")
-case class FromGeo(latitudeExpr: Expression, longitudeExpr: Expression, resolutionExpr: Expression,
+case class FromGeo(first: Expression, second: Expression, third: Expression,
                    failOnError: Boolean = SQLConf.get.ansiEnabled)
   extends TernaryExpression with CodegenFallback with ImplicitCastInputTypes with NullIntolerant {
 
-  def this(latitudeExpr: Expression, longitudeExpr: Expression, resolutionExpr: Expression) =
-    this(latitudeExpr, longitudeExpr, resolutionExpr, SQLConf.get.ansiEnabled)
+  def this(first: Expression, second: Expression, third: Expression) =
+    this(first, second, third, SQLConf.get.ansiEnabled)
 
   override def inputTypes: Seq[DataType] = Seq(DoubleType, DoubleType, IntegerType)
   override def dataType: DataType = LongType
-  override def children: Seq[Expression] = Seq(latitudeExpr, longitudeExpr, resolutionExpr)
   override def nullable: Boolean = !failOnError || super.nullable
 
   override protected def nullSafeEval(latitudeAny: Any, longitudeAny: Any, resolutionAny: Any): Any = {
@@ -57,4 +56,7 @@ case class FromGeo(latitudeExpr: Expression, longitudeExpr: Expression, resoluti
       case _: IllegalArgumentException if !failOnError => null
     }
   }
+
+  override protected def withNewChildrenInternal(newFirst: Expression, newSecond: Expression, newThird: Expression): FromGeo =
+    copy(first = newFirst, second = newSecond, third = newThird)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/FromWkt.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/FromWkt.scala
@@ -16,8 +16,8 @@ import org.locationtech.jts.io.{ParseException, WKTReader}
 /**
  * Return h3 address from a WKT string.
  *
- * @param wktExpr point in WKT format.
- * @param resolutionExpr h3 resolution
+ * @param left point in WKT format.
+ * @param right h3 resolution
  */
 @ExpressionDescription(
   usage = "_FUNC_(wkt, resolution) - Returns h3 address from a WKT string at target resolution.",
@@ -36,15 +36,13 @@ import org.locationtech.jts.io.{ParseException, WKTReader}
           NULL
      """,
   since = "0.1.0")
-case class FromWkt(wktExpr: Expression, resolutionExpr: Expression,
+case class FromWkt(left: Expression, right: Expression,
                    failOnError: Boolean = SQLConf.get.ansiEnabled)
   extends BinaryExpression with CodegenFallback with ImplicitCastInputTypes with NullIntolerant {
 
-  def this(wktExpr: Expression, resolutionExpr: Expression) =
-    this(wktExpr, resolutionExpr, SQLConf.get.ansiEnabled)
+  def this(left: Expression, right: Expression) =
+    this(left, right, SQLConf.get.ansiEnabled)
 
-  override def left: Expression = wktExpr
-  override def right: Expression = resolutionExpr
   override def inputTypes: Seq[DataType] = Seq(StringType, IntegerType)
   override def dataType: DataType = LongType
   override def nullable: Boolean = true
@@ -69,4 +67,6 @@ case class FromWkt(wktExpr: Expression, resolutionExpr: Expression,
       case _: ParseException | _: IllegalArgumentException if !failOnError => null
     }
   }
+
+  override protected def withNewChildrenInternal(newLeft: Expression, newRight: Expression): FromWkt = copy(left = newLeft, right = newRight)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/FunctionCatalog.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/FunctionCatalog.scala
@@ -87,7 +87,8 @@ object FunctionCatalog {
         ed.note(),
         ed.group(),
         ed.since(),
-        ed.deprecated())
+        ed.deprecated(),
+        ed.source())
     } else {
       new ExpressionInfo(clazz.getCanonicalName, name)
     }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/GetResolution.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/GetResolution.scala
@@ -13,7 +13,7 @@ import org.apache.spark.sql.types.{DataType, IntegerType, LongType}
 /**
  * Returns the resolution of h3 index.
  *
- * @param h3Expr h3 index.
+ * @param child h3 index.
  */
 @ExpressionDescription(
   usage = "_FUNC_(h3) - Returns the resolution of h3 index.",
@@ -28,10 +28,9 @@ import org.apache.spark.sql.types.{DataType, IntegerType, LongType}
           10
      """,
   since = "0.1.0")
-case class GetResolution(h3Expr: Expression)
+case class GetResolution(child: Expression)
   extends UnaryExpression with CodegenFallback with ImplicitCastInputTypes with NullIntolerant {
 
-  override def child: Expression = h3Expr
   override def inputTypes: Seq[DataType] = Seq(LongType)
   override def dataType: DataType = IntegerType
 
@@ -39,4 +38,6 @@ case class GetResolution(h3Expr: Expression)
     val h3 = h3Any.asInstanceOf[Long]
     H3.getInstance().h3GetResolution(h3)
   }
+
+  override protected def withNewChildInternal(newChild: Expression): GetResolution = copy(child = newChild)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/HexRing.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/HexRing.scala
@@ -18,8 +18,8 @@ import scala.collection.JavaConverters._
 /**
  * Returns the hollow hexagonal ring centered at origin with sides of length k.
  *
- * @param originExpr h3 origin.
- * @param kExpr k distance.
+ * @param left h3 origin.
+ * @param right k distance.
  */
 @ExpressionDescription(
   usage = "_FUNC_(h3, k) - Returns the hollow hexagonal ring centered at origin with sides of length k.",
@@ -37,15 +37,13 @@ import scala.collection.JavaConverters._
      """,
   group = "array_funcs",
   since = "0.1.0")
-case class HexRing(originExpr: Expression, kExpr: Expression,
+case class HexRing(left: Expression, right: Expression,
                    failOnError: Boolean = SQLConf.get.ansiEnabled)
   extends BinaryExpression with CodegenFallback with ImplicitCastInputTypes with NullIntolerant {
 
-  def this(originExpr: Expression, kExpr: Expression) =
-    this(originExpr, kExpr, SQLConf.get.ansiEnabled)
+  def this(left: Expression, right: Expression) =
+    this(left, right, SQLConf.get.ansiEnabled)
 
-  override def left: Expression = originExpr
-  override def right: Expression = kExpr
   override def inputTypes: Seq[DataType] = Seq(LongType, IntegerType)
   override def dataType: DataType = ArrayType(LongType, containsNull = false)
   override def nullable: Boolean = !failOnError || super.nullable
@@ -59,4 +57,6 @@ case class HexRing(originExpr: Expression, kExpr: Expression,
       case _: PentagonEncounteredException if !failOnError => null
     }
   }
+
+  override protected def withNewChildrenInternal(newLeft: Expression, newRight: Expression): HexRing = copy(left = newLeft, right = newRight)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/IsPentagon.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/IsPentagon.scala
@@ -13,7 +13,7 @@ import org.apache.spark.sql.types.{BooleanType, DataType, LongType}
 /**
  * Returns true if it's a pentagon h3 index.
  *
- * @param h3Expr h3 index.
+ * @param child h3 index.
  */
 @ExpressionDescription(
   usage = "_FUNC_(h3) - Returns true if it's a pentagon h3 index.",
@@ -28,10 +28,9 @@ import org.apache.spark.sql.types.{BooleanType, DataType, LongType}
           false
      """,
   since = "0.7.0")
-case class IsPentagon(h3Expr: Expression)
+case class IsPentagon(child: Expression)
   extends UnaryExpression with CodegenFallback with ImplicitCastInputTypes with NullIntolerant {
 
-  override def child: Expression = h3Expr
   override def inputTypes: Seq[DataType] = Seq(LongType)
   override def dataType: DataType = BooleanType
 
@@ -39,4 +38,6 @@ case class IsPentagon(h3Expr: Expression)
     val h3 = h3Any.asInstanceOf[Long]
     H3.getInstance().h3IsPentagon(h3)
   }
+
+  override protected def withNewChildInternal(newChild: Expression): IsPentagon = copy(child = newChild)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/IsValid.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/IsValid.scala
@@ -13,7 +13,7 @@ import org.apache.spark.sql.types.{BooleanType, DataType, LongType}
 /**
  * Returns true if it's a valid h3 index.
  *
- * @param h3Expr h3 index.
+ * @param child h3 index.
  */
 @ExpressionDescription(
   usage = "_FUNC_(h3) - Returns true if it's a valid h3 index.",
@@ -30,10 +30,9 @@ import org.apache.spark.sql.types.{BooleanType, DataType, LongType}
           false
      """,
   since = "0.1.0")
-case class IsValid(h3Expr: Expression)
+case class IsValid(child: Expression)
   extends UnaryExpression with CodegenFallback with ImplicitCastInputTypes with NullIntolerant {
 
-  override def child: Expression = h3Expr
   override def inputTypes: Seq[DataType] = Seq(LongType)
   override def dataType: DataType = BooleanType
 
@@ -41,4 +40,6 @@ case class IsValid(h3Expr: Expression)
     val h3 = h3Any.asInstanceOf[Long]
     H3.getInstance().h3IsValid(h3)
   }
+
+  override protected def withNewChildInternal(newChild: Expression): IsValid = copy(child = newChild)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/KRing.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/KRing.scala
@@ -16,8 +16,8 @@ import scala.collection.JavaConverters._
 /**
  * Returns h3 indices within k distance of the origin index.
  *
- * @param originExpr h3 origin.
- * @param kExpr k distance.
+ * @param left h3 origin.
+ * @param right k distance.
  */
 @ExpressionDescription(
   usage = "_FUNC_(h3, k) - Returns h3 indices within k distance of the origin index.",
@@ -35,11 +35,9 @@ import scala.collection.JavaConverters._
      """,
   group = "array_funcs",
   since = "0.1.0")
-case class KRing(originExpr: Expression, kExpr: Expression)
+case class KRing(left: Expression, right: Expression)
   extends BinaryExpression with CodegenFallback with ImplicitCastInputTypes with NullIntolerant {
 
-  override def left: Expression = originExpr
-  override def right: Expression = kExpr
   override def inputTypes: Seq[DataType] = Seq(LongType, IntegerType)
   override def dataType: DataType = ArrayType(LongType, containsNull = false)
 
@@ -48,4 +46,6 @@ case class KRing(originExpr: Expression, kExpr: Expression)
     val k = kAny.asInstanceOf[Int]
     ArrayData.toArrayData(H3.getInstance().kRing(origin, k).asScala.toArray)
   }
+
+  override protected def withNewChildrenInternal(newLeft: Expression, newRight: Expression): KRing = copy(left = newLeft, right = newRight)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/KRingDistances.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/KRingDistances.scala
@@ -16,8 +16,8 @@ import scala.collection.JavaConverters._
 /**
  * Returns h3 indices within k distance of the origin index.
  *
- * @param originExpr h3 origin.
- * @param kExpr k distance.
+ * @param left h3 origin.
+ * @param right k distance.
  */
 @ExpressionDescription(
   usage = "_FUNC_(h3, k) - Returns h3 indices within k distance of the origin index.",
@@ -35,11 +35,9 @@ import scala.collection.JavaConverters._
      """,
   group = "array_funcs",
   since = "0.7.0")
-case class KRingDistances(originExpr: Expression, kExpr: Expression)
+case class KRingDistances(left: Expression, right: Expression)
   extends BinaryExpression with CodegenFallback with ImplicitCastInputTypes with NullIntolerant {
 
-  override def left: Expression = originExpr
-  override def right: Expression = kExpr
   override def inputTypes: Seq[DataType] = Seq(LongType, IntegerType)
   override def dataType: DataType = ArrayType(ArrayType(LongType, containsNull = false), containsNull = false)
 
@@ -49,4 +47,6 @@ case class KRingDistances(originExpr: Expression, kExpr: Expression)
     val distances = H3.getInstance().kRingDistances(origin, k)
     ArrayData.toArrayData(distances.asScala.map(i => ArrayData.toArrayData(i.asScala.toArray)))
   }
+
+  override protected def withNewChildrenInternal(newLeft: Expression, newRight: Expression): KRingDistances = copy(left = newLeft, right = newRight)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/Line.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/Line.scala
@@ -18,8 +18,8 @@ import scala.collection.JavaConverters._
 /**
  * Returns the line of indexes between start and end.
  *
- * @param startExpr h3 start.
- * @param endExpr h3 end.
+ * @param left h3 start.
+ * @param right h3 end.
  */
 @ExpressionDescription(
   usage = "_FUNC_(start, end) - Returns the line of indexes between start and end.",
@@ -37,15 +37,13 @@ import scala.collection.JavaConverters._
      """,
   group = "array_funcs",
   since = "0.1.0")
-case class Line(startExpr: Expression, endExpr: Expression,
+case class Line(left: Expression, right: Expression,
                 failOnError: Boolean = SQLConf.get.ansiEnabled)
   extends BinaryExpression with CodegenFallback with ImplicitCastInputTypes with NullIntolerant {
 
-  def this(startExpr: Expression, endExpr: Expression) =
-    this(startExpr, endExpr, SQLConf.get.ansiEnabled)
+  def this(left: Expression, right: Expression) =
+    this(left, right, SQLConf.get.ansiEnabled)
 
-  override def left: Expression = startExpr
-  override def right: Expression = endExpr
   override def inputTypes: Seq[DataType] = Seq(LongType, LongType)
   override def dataType: DataType = ArrayType(LongType, containsNull = false)
   override def nullable: Boolean = !failOnError || super.nullable
@@ -60,4 +58,6 @@ case class Line(startExpr: Expression, endExpr: Expression,
       case _: LineUndefinedException if !failOnError => null
     }
   }
+
+  override protected def withNewChildrenInternal(newLeft: Expression, newRight: Expression): Line = copy(left = newLeft, right = newRight)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/PointDistance.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/PointDistance.scala
@@ -8,21 +8,17 @@ package com.nuzigor.spark.sql.h3
 import com.nuzigor.h3.H3
 import com.uber.h3core.LengthUnit
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
-import org.apache.spark.sql.catalyst.expressions.{BinaryExpression, Expression, ImplicitCastInputTypes, NullIntolerant}
+import org.apache.spark.sql.catalyst.expressions.{BinaryExpression, ImplicitCastInputTypes, NullIntolerant}
 import org.apache.spark.sql.types.{DataType, DoubleType, LongType}
 
 /**
  * Gives the "great circle" or "haversine" distance between centers of h3 indices in units.
  */
-trait PointDistance
+abstract class PointDistance
   extends BinaryExpression with CodegenFallback with ImplicitCastInputTypes with NullIntolerant {
 
-  def startExpr: Expression
-  def endExpr: Expression
   def unit: LengthUnit
 
-  override def left: Expression = startExpr
-  override def right: Expression = endExpr
   override def inputTypes: Seq[DataType] = Seq(LongType, LongType)
   override def dataType: DataType = DoubleType
 

--- a/src/main/scala/com/nuzigor/spark/sql/h3/PointDistanceKm.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/PointDistanceKm.scala
@@ -11,8 +11,8 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescript
 /**
  * Gives the "great circle" or "haversine" distance between centers of h3 indices in kilometers.
  *
- * @param startExpr h3 start.
- * @param endExpr h3 end.
+ * @param left h3 start.
+ * @param right h3 end.
  */
 @ExpressionDescription(
   usage = "_FUNC_(start, end) - Gives the \"great circle\" or \"haversine\" distance between centers of h3 indices in kilometers.",
@@ -29,6 +29,8 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescript
           0.475
      """,
   since = "0.7.0")
-case class PointDistanceKm(startExpr: Expression, endExpr: Expression) extends PointDistance {
+case class PointDistanceKm(left: Expression, right: Expression) extends PointDistance {
   override def unit: LengthUnit = LengthUnit.km
+
+  override protected def withNewChildrenInternal(newLeft: Expression, newRight: Expression): PointDistanceKm = copy(left = newLeft, right = newRight)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/PointDistanceM.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/PointDistanceM.scala
@@ -11,8 +11,8 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescript
 /**
  * Gives the "great circle" or "haversine" distance between centers of h3 indices in meters.
  *
- * @param startExpr h3 start.
- * @param endExpr h3 end.
+ * @param left h3 start.
+ * @param right h3 end.
  */
 @ExpressionDescription(
   usage = "_FUNC_(start, end) - Gives the \"great circle\" or \"haversine\" distance between centers of h3 indices in meters.",
@@ -29,6 +29,8 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescript
           475.9
      """,
   since = "0.7.0")
-case class PointDistanceM(startExpr: Expression, endExpr: Expression) extends PointDistance {
+case class PointDistanceM(left: Expression, right: Expression) extends PointDistance {
   override def unit: LengthUnit = LengthUnit.m
+
+  override protected def withNewChildrenInternal(newLeft: Expression, newRight: Expression): PointDistanceM = copy(left = newLeft, right = newRight)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/PointDistanceRads.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/PointDistanceRads.scala
@@ -11,8 +11,8 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescript
 /**
  * Gives the "great circle" or "haversine" distance between centers of h3 indices in radians.
  *
- * @param startExpr h3 start.
- * @param endExpr h3 end.
+ * @param left h3 start.
+ * @param right h3 end.
  */
 @ExpressionDescription(
   usage = "_FUNC_(start, end) - Gives the \"great circle\" or \"haversine\" distance between centers of h3 indices in radians.",
@@ -29,6 +29,8 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescript
           7.471E-5
      """,
   since = "0.7.0")
-case class PointDistanceRads(startExpr: Expression, endExpr: Expression) extends PointDistance {
+case class PointDistanceRads(left: Expression, right: Expression) extends PointDistance {
   override def unit: LengthUnit = LengthUnit.rads
+
+  override protected def withNewChildrenInternal(newLeft: Expression, newRight: Expression): PointDistanceRads = copy(left = newLeft, right = newRight)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/ToCenterChild.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/ToCenterChild.scala
@@ -14,8 +14,8 @@ import org.apache.spark.sql.types.{DataType, IntegerType, LongType}
 /**
  * Returns the center child of h3 index at child resolution.
  *
- * @param h3Expr h3 index.
- * @param childResolutionExpr child resolution.
+ * @param left h3 index.
+ * @param right child resolution.
  */
 @ExpressionDescription(
   usage = "_FUNC_(h3, resolution) - Returns the center child of h3 index at child resolution.",
@@ -32,15 +32,13 @@ import org.apache.spark.sql.types.{DataType, IntegerType, LongType}
           631492329425011199
      """,
   since = "0.1.0")
-case class ToCenterChild(h3Expr: Expression, childResolutionExpr: Expression,
+case class ToCenterChild(left: Expression, right: Expression,
                          failOnError: Boolean = SQLConf.get.ansiEnabled)
   extends BinaryExpression with CodegenFallback with ImplicitCastInputTypes with NullIntolerant {
 
-  def this(h3Expr: Expression, childResolutionExpr: Expression) =
-    this(h3Expr, childResolutionExpr, SQLConf.get.ansiEnabled)
+  def this(left: Expression, right: Expression) =
+    this(left, right, SQLConf.get.ansiEnabled)
 
-  override def left: Expression = h3Expr
-  override def right: Expression = childResolutionExpr
   override def inputTypes: Seq[DataType] = Seq(LongType, IntegerType)
   override def dataType: DataType = LongType
   override def nullable: Boolean = !failOnError || super.nullable
@@ -55,4 +53,6 @@ case class ToCenterChild(h3Expr: Expression, childResolutionExpr: Expression,
       case _: IllegalArgumentException if !failOnError => null
     }
   }
+
+  override protected def withNewChildrenInternal(newLeft: Expression, newRight: Expression): ToCenterChild = copy(left = newLeft, right = newRight)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/ToChildren.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/ToChildren.scala
@@ -17,8 +17,8 @@ import scala.collection.JavaConverters._
 /**
  * Returns h3 indices contained within of the original index and child resolution.
  *
- * @param h3Expr h3 index.
- * @param childResolutionExpr child resolution.
+ * @param left h3 index.
+ * @param right child resolution.
  */
 @ExpressionDescription(
   usage = "_FUNC_(h3, resolution) - Returns h3 indices contained within of the original index and child resolution.",
@@ -36,15 +36,13 @@ import scala.collection.JavaConverters._
      """,
   group = "array_funcs",
   since = "0.1.0")
-case class ToChildren(h3Expr: Expression, childResolutionExpr: Expression,
+case class ToChildren(left: Expression, right: Expression,
                       failOnError: Boolean = SQLConf.get.ansiEnabled)
   extends BinaryExpression with CodegenFallback with ImplicitCastInputTypes with NullIntolerant {
 
-  def this(h3Expr: Expression, childResolutionExpr: Expression) =
-    this(h3Expr, childResolutionExpr, SQLConf.get.ansiEnabled)
+  def this(left: Expression, right: Expression) =
+    this(left, right, SQLConf.get.ansiEnabled)
 
-  override def left: Expression = h3Expr
-  override def right: Expression = childResolutionExpr
   override def inputTypes: Seq[DataType] = Seq(LongType, IntegerType)
   override def dataType: DataType = ArrayType(LongType, containsNull = false)
   override def nullable: Boolean = !failOnError || super.nullable
@@ -65,4 +63,6 @@ case class ToChildren(h3Expr: Expression, childResolutionExpr: Expression,
       case _: IllegalArgumentException if !failOnError => null
     }
   }
+
+  override protected def withNewChildrenInternal(newLeft: Expression, newRight: Expression): ToChildren = copy(left = newLeft, right = newRight)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/ToParent.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/ToParent.scala
@@ -14,8 +14,8 @@ import org.apache.spark.sql.types.{DataType, IntegerType, LongType}
 /**
  * Returns the parent (coarser) index containing h3.
  *
- * @param h3Expr h3 index.
- * @param parentResolutionExpr parent resolution.
+ * @param left h3 index.
+ * @param right parent resolution.
  */
 @ExpressionDescription(
   usage = "_FUNC_(h3, resolution) - Returns the parent (coarser) index containing h3.",
@@ -32,15 +32,13 @@ import org.apache.spark.sql.types.{DataType, IntegerType, LongType}
           617981530542964735
      """,
   since = "0.1.0")
-case class ToParent(h3Expr: Expression, parentResolutionExpr: Expression,
+case class ToParent(left: Expression, right: Expression,
                     failOnError: Boolean = SQLConf.get.ansiEnabled)
   extends BinaryExpression with CodegenFallback with ImplicitCastInputTypes with NullIntolerant {
 
-  def this(h3Expr: Expression, parentResolutionExpr: Expression) =
-    this(h3Expr, parentResolutionExpr, SQLConf.get.ansiEnabled)
+  def this(left: Expression, right: Expression) =
+    this(left, right, SQLConf.get.ansiEnabled)
 
-  override def left: Expression = h3Expr
-  override def right: Expression = parentResolutionExpr
   override def inputTypes: Seq[DataType] = Seq(LongType, IntegerType)
   override def dataType: DataType = LongType
   override def nullable: Boolean = !failOnError || super.nullable
@@ -55,4 +53,6 @@ case class ToParent(h3Expr: Expression, parentResolutionExpr: Expression,
       case _: IllegalArgumentException if !failOnError => null
     }
   }
+
+  override protected def withNewChildrenInternal(newLeft: Expression, newRight: Expression): ToParent = copy(left = newLeft, right = newRight)
 }

--- a/src/main/scala/com/nuzigor/spark/sql/h3/Uncompact.scala
+++ b/src/main/scala/com/nuzigor/spark/sql/h3/Uncompact.scala
@@ -17,8 +17,8 @@ import scala.collection.JavaConverters._
 /**
  * Uncompacts the set of indices using the target resolution.
  *
- * @param h3Expr h3 indices.
- * @param resolutionExpr h3 resolution
+ * @param left h3 indices.
+ * @param right h3 resolution
  */
 @ExpressionDescription(
   usage = "_FUNC_(h3, resolution) - Un-compacts the set of indices using the target resolution.",
@@ -36,17 +36,15 @@ import scala.collection.JavaConverters._
      """,
   group = "array_funcs",
   since = "0.1.0")
-case class Uncompact(h3Expr: Expression, resolutionExpr: Expression,
+case class Uncompact(left: Expression, right: Expression,
                      failOnError: Boolean = SQLConf.get.ansiEnabled)
   extends BinaryExpression with CodegenFallback with ImplicitCastInputTypes with NullIntolerant with ArrayListConversion {
 
-  def this(h3Expr: Expression, resolutionExpr: Expression) =
-    this(h3Expr, resolutionExpr, SQLConf.get.ansiEnabled)
+  def this(left: Expression, right: Expression) =
+    this(left, right, SQLConf.get.ansiEnabled)
 
   @transient private lazy val nullEntries: Boolean = left.dataType.asInstanceOf[ArrayType].containsNull
 
-  override def left: Expression = h3Expr
-  override def right: Expression = resolutionExpr
   override def inputTypes: Seq[DataType] = Seq(ArrayType(LongType), IntegerType)
   override def dataType: DataType = ArrayType(LongType, containsNull = false)
   override def nullable: Boolean = !failOnError || left.nullable || right.nullable || nullEntries
@@ -65,4 +63,6 @@ case class Uncompact(h3Expr: Expression, resolutionExpr: Expression,
       case None => null
     }
   }
+
+  override protected def withNewChildrenInternal(newLeft: Expression, newRight: Expression): Uncompact = copy(left = newLeft, right = newRight)
 }

--- a/src/test/scala/com/nuzigor/spark/sql/h3/H3Spec.scala
+++ b/src/test/scala/com/nuzigor/spark/sql/h3/H3Spec.scala
@@ -32,7 +32,7 @@ abstract class H3Spec extends AnyFlatSpec {
   protected val resourceFolder: String = System.getProperty("user.dir") + "/../core/src/test/resources/"
 
   // scalastyle:off magic.number
-  protected val invalidResolutions = Seq(-1, 16)
+  protected val invalidResolutions: Seq[Int] = Seq(-1, 16)
   // scalastyle:on magic.number
 
   protected lazy val sparkSession: SparkSession = SparkSession
@@ -56,9 +56,6 @@ abstract class H3Spec extends AnyFlatSpec {
       }
     }
     (keys, values).zipped.foreach { (k, v) =>
-      if (SQLConf.staticConfKeys.contains(k)) {
-        throw new Exception(s"Cannot modify the value of a static config: $k")
-      }
       conf.setConfString(k, v)
     }
     try f finally {


### PR DESCRIPTION
Use latest versions of libraries
Fix code after breaking Spark changes (from 3.1.2 to 3.2.1)